### PR TITLE
re-link Zenodo badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/EcologicalSemantics/an-ontology-of-core-ecological-entities.svg?branch=master)](https://travis-ci.org/EcologicalSemantics/an-ontology-of-core-ecological-entities)
-[![DOI](https://zenodo.org/badge/13996/EcologicalSemantics/an-ontology-of-core-ecological-entities.svg)](https://zenodo.org/badge/latestdoi/13996/EcologicalSemantics/an-ontology-of-core-ecological-entities)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.846451.svg)](https://zenodo.org/record/846451)
 
 # ecoCore: An ontology of core ecological entities
 ## In brief


### PR DESCRIPTION
Hello @pbuttigieg!

The old badge link led to a `Page not found`. This suggestion points to the only other hit for `EcologicalSemantics` or `ecocore` in Zenodo.

Cheers :-)