### PR TITLE
Fix ill-formatted ISBN annotations in `ecocore-edit.owl`

### DIFF
--- a/src/ontology/ecocore-edit.owl
+++ b/src/ontology/ecocore-edit.owl
@@ -373,7 +373,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/ECOCORE_00000017> ObjectSomeValuesFro
 
 # Class: <http://purl.obolibrary.org/obo/ECOCORE_00000018> (life history)
 
-AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "ISBN 13: 9781305967335") Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "ISBN: 130596733X") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/ECOCORE_00000018> "A history which includes all the processes during which resources are used by an organism to grow, survive, and reproduce over its lifetime.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "ISBN:9781305967335") Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "ISBN:130596733X") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/ECOCORE_00000018> "A history which includes all the processes during which resources are used by an organism to grow, survive, and reproduce over its lifetime.")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000117> <http://purl.obolibrary.org/obo/ECOCORE_00000018> "http://orcid.org/0000-0002-4364-7715")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000117> <http://purl.obolibrary.org/obo/ECOCORE_00000018> "http://orcid.org/0000-0002-4366-3088")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/ECOCORE_00000018> "life history"@en)


### PR DESCRIPTION
Hi there!

I'm working with @cmungall to improve the OBO format, and the current version of `ecocore.obo` is not up to the latest specification (v1.4). This is partly due to ENVO not being up to the standard either, but `ecocore-edit.owl` contains some issues nevertheless. This PR fixes invalid ISBN identifiers in the editor's file; I'll open a PR when ENVO is updated in order to update the local imported version.